### PR TITLE
Fix AirBender when playing with a controller & precise eitr cost check

### DIFF
--- a/AlmanacClasses/Classes/Abilities/AbilityManager.cs
+++ b/AlmanacClasses/Classes/Abilities/AbilityManager.cs
@@ -203,7 +203,9 @@ public static class AbilityManager
     {
         float cost = talent.GetEitrCost(false);
         if (cost == 0f) return true;
-        if (Player.m_localPlayer.HaveEitr(cost)) return true;
+        // The HaveEitr method checks if the player's eitr is > the amount of eitr passed in instead of >=
+        // Pass in the cost - 1 to allow using abilities when the player has the exact amount required
+        if (Player.m_localPlayer.HaveEitr(cost - 1)) return true;
         Hud.instance.EitrBarEmptyFlash();
         Player.m_localPlayer.Message(MessageHud.MessageType.Center, "$hud_eitrrequired");
         return false;

--- a/AlmanacClasses/Classes/Abilities/Core/AirBender.cs
+++ b/AlmanacClasses/Classes/Abilities/Core/AirBender.cs
@@ -30,7 +30,7 @@ public static class AirBender
         bool flag = false;
 
         float eitrCost = talent.GetEitrCost(true, talent.GetLevel());
-        if (!instance.HaveEitr(eitrCost))
+        if (!instance.HaveEitr(eitrCost - 1))
         {
             Hud.instance.EitrBarEmptyFlash();
             return;
@@ -62,7 +62,7 @@ public static class AirBender
         bool flag = false;
 
         float eitrCost = talent.GetEitrCost(false);
-        if (!instance.HaveEitr(eitrCost))
+        if (!instance.HaveEitr(eitrCost - 1))
         {
             Hud.instance.EitrBarEmptyFlash();
             return;

--- a/AlmanacClasses/Classes/Abilities/Core/AirBender.cs
+++ b/AlmanacClasses/Classes/Abilities/Core/AirBender.cs
@@ -25,8 +25,8 @@ public static class AirBender
         if (!instance) return;
         if (!PlayerManager.m_playerTalents.TryGetValue("AirBenderAlt", out Talent talent)) return;
         if (instance.IsOnGround()) return;
-        
-        if (!ZInput.GetButtonDown("Jump")) return;
+
+        if (!(ZInput.GetButtonDown("Jump") || ZInput.GetButtonDown("JoyJump"))) return;
         bool flag = false;
 
         float eitrCost = talent.GetEitrCost(true, talent.GetLevel());
@@ -54,8 +54,8 @@ public static class AirBender
             JumpCount = 0;
             return;
         }
-        
-        if (!ZInput.GetButtonDown("Jump")) return;
+
+        if (!(ZInput.GetButtonDown("Jump") || ZInput.GetButtonDown("JoyJump"))) return;
 
         if (JumpCount >= talent.GetLevel()) return;
         


### PR DESCRIPTION
Fixes AirBender's double jump ability not working on a controller. (issue #13 )
Fixes abilities requiring (but not using) 1 more eitr than their cost to cast. In other words: ensure you can cast a 10 eitr ability when you have exactly 10 eitr.  (related to issue #4 )